### PR TITLE
add filtering by tags for newsPage

### DIFF
--- a/green_city_sh.Tests/Components/NewsCardComponent.cs
+++ b/green_city_sh.Tests/Components/NewsCardComponent.cs
@@ -4,12 +4,34 @@ namespace green_city_sh.Tests.Components
 {
     public class NewsCardComponent : BaseComponent
     {
+        private By TagsInCard => By.CssSelector(".filter-tag .ul-eco-buttons span");
+
         public NewsCardComponent(IWebDriver driver, By rootLocator) : base(driver, rootLocator)
         {
         }
 
         public NewsCardComponent(IWebDriver driver, IWebElement componentRoot) : base(driver, componentRoot)
         {
+        }
+
+        /// <summary>
+        /// Returns a list of tags for the current news card.
+        /// </summary>
+        public List<string> GetTags()
+        {
+            var tagElements = RootElement.FindElements(TagsInCard);
+            var tags = new List<string>();
+
+            foreach (var element in tagElements)
+            {
+                var text = element.Text.Trim();
+                if (!string.IsNullOrEmpty(text) && text != "|")
+                {
+                    tags.Add(text);
+                }
+            }
+
+            return tags;
         }
     }
 }

--- a/green_city_sh.Tests/Components/NewsListComponent.cs
+++ b/green_city_sh.Tests/Components/NewsListComponent.cs
@@ -88,4 +88,9 @@ public class NewsListComponent : BaseComponent
 
         return cards;
     }
+
+    public void WaitForCardsToLoad()
+    {
+        wait.Until(driver => GetNewsCards() > 0);
+    }
 }

--- a/green_city_sh.Tests/Components/NewsListComponent.cs
+++ b/green_city_sh.Tests/Components/NewsListComponent.cs
@@ -73,5 +73,19 @@ public class NewsListComponent : BaseComponent
         
     }
 
+    /// <summary>
+    /// Returns all news cards as a list of NewsCardComponent components.
+    /// </summary>
+    public List<NewsCardComponent> GetAllNewsCardsAsComponents()
+    {
+        var cardElements = GetNewsCardElements();
+        var cards = new List<NewsCardComponent>();
 
+        foreach (var cardElement in cardElements)
+        {
+            cards.Add(new NewsCardComponent(driver, cardElement));
+        }
+
+        return cards;
+    }
 }

--- a/green_city_sh.Tests/Components/NewsTagsComponent.cs
+++ b/green_city_sh.Tests/Components/NewsTagsComponent.cs
@@ -26,7 +26,7 @@ public class NewsTagsComponent : TagsComponent
     {
         var tagButton = RootElement.FindElement(TagButtonByName(name));
         tagButton.Click();
-        Thread.Sleep(500);
+        wait.Until(driver => tagButton.GetAttribute("class").Contains("global-tag-clicked"));
     }
 
     public void SelectTags(params string[] tags)
@@ -61,8 +61,6 @@ public class NewsTagsComponent : TagsComponent
                .ClickAndHold()
                .Release()
                .Perform();
-
-        Thread.Sleep(1000);
     }
 
     public bool IsTagSelected(string name)
@@ -78,10 +76,14 @@ public class NewsTagsComponent : TagsComponent
 
     public void ClearAllFilters()
     {
-        var selectedTags = RootElement.FindElements(SelectedTags);
-        foreach (var tag in selectedTags)
+        while (true)
         {
-            tag.Click();
+            var selectedTags = RootElement.FindElements(SelectedTags);
+            if (selectedTags.Count == 0) break;
+
+            selectedTags[0].Click();
+            wait.Until(driver =>
+                RootElement.FindElements(SelectedTags).Count < selectedTags.Count);
         }
     }
 

--- a/green_city_sh.Tests/Components/NewsTagsComponent.cs
+++ b/green_city_sh.Tests/Components/NewsTagsComponent.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Interactions;
 
 namespace green_city_sh.Tests.Components;
 
@@ -23,21 +24,81 @@ public class NewsTagsComponent : TagsComponent
 
     public void SelectTag(string name)
     {
-        
+        var tagButton = RootElement.FindElement(TagButtonByName(name));
+        tagButton.Click();
+        Thread.Sleep(500);
     }
 
     public void SelectTags(params string[] tags)
     {
-        
+        foreach (var tag in tags)
+        {
+            SelectTag(tag);
+        }
+    }
+    public void SelectTagWithRealClick(string name)
+    {
+        var allTagButtons = RootElement.FindElements(TagButtons);
+
+        IWebElement targetButton = null;
+        foreach (var button in allTagButtons)
+        {
+            var tagText = button.FindElement(By.CssSelector(".text")).Text.Trim();
+            if (tagText.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                targetButton = button;
+                break;
+            }
+        }
+
+        if (targetButton == null)
+            throw new NoSuchElementException($"Tag '{name}' not found");
+
+        var tagLink = targetButton.FindElement(By.CssSelector("a.global-tag"));
+
+        var actions = new Actions(driver);
+        actions.MoveToElement(tagLink)
+               .ClickAndHold()
+               .Release()
+               .Perform();
+
+        Thread.Sleep(1000);
     }
 
     public bool IsTagSelected(string name)
     {
-               return false;
+        var elements = RootElement.FindElements(SelectedTagByName(name));
+        return elements.Count > 0;
     }
 
     public int GetSelectedTagsCount()
     {
-               return 0;
+        return RootElement.FindElements(SelectedTags).Count;
+    }
+
+    public void ClearAllFilters()
+    {
+        var selectedTags = RootElement.FindElements(SelectedTags);
+        foreach (var tag in selectedTags)
+        {
+            tag.Click();
+        }
+    }
+
+    /// <summary>
+    /// Returns a list of the names of all available tags on the page.
+    /// </summary>
+    public List<string> GetAllAvailableTags()
+    {
+        var tagButtons = RootElement.FindElements(TagButtons);
+        var tags = new List<string>();
+
+        foreach (var button in tagButtons)
+        {
+            var tagName = button.FindElement(By.CssSelector(".text")).Text.Trim();
+            tags.Add(tagName);
+        }
+
+        return tags;
     }
 }

--- a/green_city_sh.Tests/Pages/NewsPage.cs
+++ b/green_city_sh.Tests/Pages/NewsPage.cs
@@ -20,7 +20,7 @@ public class NewsPage : BasePage
     public NewsPage(IWebDriver driver) : base(driver)
     {
         TopBar = new NewsTopBarComponent(driver, driver.FindElement(TopBarRoot));
-        TagsFilter = new NewsTagsComponent(driver, By.CssSelector(".wrapper"));
+        TagsFilter = new NewsTagsComponent(driver, By.CssSelector("app-tag-filter"));
         Filters = new NewsFilterSelectionComponent(driver, driver.FindElement(FilterRoot));
         List = new NewsListComponent(driver, driver.FindElement(ListRoot));
     }

--- a/green_city_sh.Tests/Pages/NewsPage.cs
+++ b/green_city_sh.Tests/Pages/NewsPage.cs
@@ -1,21 +1,26 @@
 using OpenQA.Selenium;
 using green_city_sh.Tests.Components;
+using green_city_sh.Tests.Infrastructure;
 
 namespace green_city_sh.Tests.Pages;
 
 public class NewsPage : BasePage
 {
     public NewsTopBarComponent TopBar { get;}
+    public NewsTagsComponent TagsFilter { get;}
     public NewsFilterSelectionComponent Filters { get;  }
     public NewsListComponent List { get;}
 
     private By TopBarRoot => By.CssSelector(".main-header");
-    private By FilterRoot => By.CssSelector(".ul-eco-buttons");
+    private By FilterRoot => By.CssSelector("app-tag-filter .ul-eco-buttons");
     private By ListRoot => By.CssSelector(".list-wrapper");
+
+    private By ItemsFoundCounter => By.CssSelector("app-remaining-count h2");
 
     public NewsPage(IWebDriver driver) : base(driver)
     {
         TopBar = new NewsTopBarComponent(driver, driver.FindElement(TopBarRoot));
+        TagsFilter = new NewsTagsComponent(driver, By.CssSelector(".wrapper"));
         Filters = new NewsFilterSelectionComponent(driver, driver.FindElement(FilterRoot));
         List = new NewsListComponent(driver, driver.FindElement(ListRoot));
     }

--- a/green_city_sh.Tests/Pages/NewsPage.cs
+++ b/green_city_sh.Tests/Pages/NewsPage.cs
@@ -1,27 +1,24 @@
 using OpenQA.Selenium;
 using green_city_sh.Tests.Components;
-using green_city_sh.Tests.Infrastructure;
 
 namespace green_city_sh.Tests.Pages;
 
 public class NewsPage : BasePage
 {
     public NewsTopBarComponent TopBar { get;}
-    public NewsTagsComponent TagsFilter { get;}
     public NewsFilterSelectionComponent Filters { get;  }
+    public NewsTagsComponent TagsFilter { get; }
     public NewsListComponent List { get;}
 
     private By TopBarRoot => By.CssSelector(".main-header");
-    private By FilterRoot => By.CssSelector("app-tag-filter .ul-eco-buttons");
+    private By FilterRoot => By.CssSelector(".ul-eco-buttons");
     private By ListRoot => By.CssSelector(".list-wrapper");
-
-    private By ItemsFoundCounter => By.CssSelector("app-remaining-count h2");
 
     public NewsPage(IWebDriver driver) : base(driver)
     {
         TopBar = new NewsTopBarComponent(driver, driver.FindElement(TopBarRoot));
-        TagsFilter = new NewsTagsComponent(driver, By.CssSelector("app-tag-filter"));
         Filters = new NewsFilterSelectionComponent(driver, driver.FindElement(FilterRoot));
+        TagsFilter = new NewsTagsComponent(driver, driver.FindElement(FilterRoot));
         List = new NewsListComponent(driver, driver.FindElement(ListRoot));
     }
 

--- a/green_city_sh.Tests/Tests/NewsPageTests.cs
+++ b/green_city_sh.Tests/Tests/NewsPageTests.cs
@@ -3,6 +3,8 @@ using green_city_sh.Tests.Infrastructure;
 using green_city_sh.Tests.Pages;
 using NUnit.Framework;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using SeleniumExtras.WaitHelpers;
 
 namespace green_city_sh.Tests.Tests;
 
@@ -20,11 +22,9 @@ public class NewsPageTests : BaseTest
 
         header.ChangeLanguage("En");
         header.ClickSignIn();
-
         var signInModal = SignInModalComponent.WaitAndCreate(Driver);
-        signInModal.Login(Configuration.TestEmail, Configuration.TestPassword);
 
-        Thread.Sleep(1000);
+        signInModal.Login(Configuration.TestEmail, Configuration.TestPassword);
 
         Driver.Navigate().GoToUrl("https://www.greencity.cx.ua/#/greenCity/news");
         newsPage = new NewsPage(Driver);
@@ -40,15 +40,15 @@ public class NewsPageTests : BaseTest
         var allTags = newsPage.TagsFilter.GetAllAvailableTags();
         Assert.That(allTags, Is.Not.Empty, "No tags found on the page");
 
-        int tagsToTestCount = Math.Min(6, allTags.Count);
-        var tagsToTest = allTags.Take(tagsToTestCount).ToList();
-
-        for (int i = 0; i < tagsToTest.Count; i++)
+        for (int i = 0; i < allTags.Count; i++)
         {
-            var tag = tagsToTest[i];
+            var tag = allTags[i];
 
             newsPage.TagsFilter.SelectTagWithRealClick(tag);
 
+            bool isSelected = newsPage.TagsFilter.IsTagSelected(tag);
+
+            newsPage.List.WaitForCardsToLoad();
             var displayedCards = newsPage.List.GetAllNewsCardsAsComponents();
 
             Assert.That(displayedCards, Is.Not.Empty,

--- a/green_city_sh.Tests/Tests/NewsPageTests.cs
+++ b/green_city_sh.Tests/Tests/NewsPageTests.cs
@@ -1,0 +1,66 @@
+﻿using green_city_sh.Tests.Components;
+using green_city_sh.Tests.Infrastructure;
+using green_city_sh.Tests.Pages;
+using NUnit.Framework;
+using OpenQA.Selenium;
+
+namespace green_city_sh.Tests.Tests;
+
+[TestFixture]
+public class NewsPageTests : BaseTest
+{
+    private NewsPage? newsPage;
+    private HeaderComponent? header;
+
+    protected override void OnSetup()
+    {
+        Driver!.Manage().Window.Maximize();
+        NavigateToBaseUrl();
+        header = new HeaderComponent(Driver, Driver!.FindElement(By.CssSelector("header")));
+
+        header.ChangeLanguage("En");
+        header.ClickSignIn();
+
+        var signInModal = SignInModalComponent.WaitAndCreate(Driver);
+        signInModal.Login(Configuration.TestEmail, Configuration.TestPassword);
+
+        Thread.Sleep(1000);
+
+        Driver.Navigate().GoToUrl("https://www.greencity.cx.ua/#/greenCity/news");
+        newsPage = new NewsPage(Driver);
+    }
+
+    [Test]
+    [Description("Filter news by tags - verify each tag shows relevant news and counter updates correctly")]
+    [Category("Smoke")]
+    public void FilterNewsByTags_ShowsOnlyNewsWithThatTag()
+    {
+        Assert.That(newsPage, Is.Not.Null, "NewsPage was not initialized");
+
+        var allTags = newsPage.TagsFilter.GetAllAvailableTags();
+        Assert.That(allTags, Is.Not.Empty, "No tags found on the page");
+
+        int tagsToTestCount = Math.Min(6, allTags.Count);
+        var tagsToTest = allTags.Take(tagsToTestCount).ToList();
+
+        for (int i = 0; i < tagsToTest.Count; i++)
+        {
+            var tag = tagsToTest[i];
+
+            newsPage.TagsFilter.SelectTagWithRealClick(tag);
+
+            var displayedCards = newsPage.List.GetAllNewsCardsAsComponents();
+
+            Assert.That(displayedCards, Is.Not.Empty,
+                $"No cards displayed after filtering by '{tag}'");
+
+            foreach (var card in displayedCards)
+            {
+                var cardTags = card.GetTags();
+                Assert.That(cardTags, Does.Contain(tag.ToUpper()),
+                    $"Card tags [{string.Join(", ", cardTags)}] do not contain '{tag}'");
+            }
+            newsPage.TagsFilter.SelectTagWithRealClick(tag);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add filtering by tags for NewsPage

## Changes
- Implemented news filter test to verify tags work correctly
- Test checks first 6 tags (or all if less than 6)
- For each tag: click → verify cards contain tag

## Test Case
TC-26: Filter news by selected tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for tag-based news filtering that perform real click interactions, verify selected state and counts, clear filters, wait for results, and assert filtered results contain the chosen tags.
  * Added test helpers to extract tags from news cards and to represent news items as testable components.

* **UI / Behavior**
  * Exposed tag-filter interaction surface and loading/wait behavior for more reliable filtering and result validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->